### PR TITLE
Include missing originalVendor parameter in updateVendor call

### DIFF
--- a/src/components/Vendors/VendorForm.jsx
+++ b/src/components/Vendors/VendorForm.jsx
@@ -27,17 +27,6 @@ import { addVendor, updateVendor } from '../../util/aws';
 import { defaultVendor } from './defaultVendor';
 import sleep from '../../util/sleep';
 
-const vendorKeys = [
-  'vendor_name',
-  'address',
-  'inventory_file_config',
-  'cost_map_config',
-  'sku_map_config',
-  'cost_adjustment_config',
-  'classification_config',
-  'inclusion_config',
-];
-
 const requiredKeys = ['vendor_name', 'address', 'inventory_file_config'];
 
 const formatLabel = (key) => {
@@ -73,9 +62,9 @@ export default function VendorForm({ ref, vendor, setFormData, setRefresh }) {
     }
   };
 
-  const awsFunctionCall = (func, vendor) => {
+  const awsFunctionCall = (func, ...vendorData) => {
     setLoading(true);
-    func(vendor).then(() => {
+    func(...vendorData).then(() => {
       setRefresh(true);
       setLoading(false);
       setSuccess(true);
@@ -104,7 +93,7 @@ export default function VendorForm({ ref, vendor, setFormData, setRefresh }) {
       }
     } else {
       if (vendorChanged) {
-        awsFunctionCall(updateVendor, editedVendor);
+        awsFunctionCall(updateVendor, originalVendor, editedVendor);
       } else {
         setAlert({
           hidden: false,
@@ -166,7 +155,7 @@ export default function VendorForm({ ref, vendor, setFormData, setRefresh }) {
         <Divider />
         <CardContent>
           <List>
-            {vendorKeys.map((key) => {
+            {Object.keys(defaultVendor).map((key) => {
               return key === 'vendor_name' ? (
                 <Box marginBottom={1.5}>
                   <TextField
@@ -184,7 +173,7 @@ export default function VendorForm({ ref, vendor, setFormData, setRefresh }) {
                 <ExpandableFormSection
                   key={key}
                   title={formatLabel(key)}
-                  formData={editedVendor[key]}
+                  formData={{ ...defaultVendor[key], ...editedVendor[key] }}
                   required={requiredKeys.includes(key)}
                   onChange={(e) => {
                     onChangeHandler(key, e);

--- a/src/util/aws.js
+++ b/src/util/aws.js
@@ -35,9 +35,11 @@ export const updateVendor = async (originalVendor, editedVendor) => {
 };
 
 export const addVendor = async (vendor) => {
+  console.log(vendor);
+  let cleanedVendor = cleanNullObjectData(vendor);
   await DYNAMODB.putItem({
     TableName: TABLE_NAME,
-    Item: marshall(cleanNullObjectData(vendor)),
+    Item: marshall(cleanedVendor),
   });
 };
 


### PR DESCRIPTION
## Changes made

### Vendor editing bug resolution
Addresses a bug from issue #1 by modifying the `awsFunctionCall` function in `VendorForms.jsx` to accept a variable number of parameters by defining a `...vendorData` parameter with the spread operator. The result is that now the `updateVendor` call can receive both parameters while the `addVendor` call can receive its single parameter using the same encapsulating function.

### Vendor form expandable section restructure
Another bug was noticed when editing a vendor. Input fields were generated by iterating over the vendor data object keys for each section. This resulted in missing inputs for keys not included in the vendor being edited. 

- *The issue:* a vendor without optional parameters could not have them added due to the missing input fields.
- *Resolution:* when passing in form data to each expandable section an object filled with the default vendor data and subsequently filled with the actual vendor data ensures the presence of all fields with missing attributes as empty inputs. This also ensures all form views will be identical as they are first structured from the `defaultVendor` object.


Here is the resolution as stated in the issue:
> Bug was caused by a missing parameter to updateVendors call in the onSaveHandler function in the VendorForm.jsx component file. This has been resolved with [the following commit](https://github.com/Factory-Wheel-Warehouse/employee-portal/commit/98e3462e1efdff106cb678fad4ec6fa60d9c7a8e)

## Testing
- `npm start`
- User testing + manual verification